### PR TITLE
Don't call state.activate when component is not swipeable

### DIFF
--- a/src/components/SwipeableView.tsx
+++ b/src/components/SwipeableView.tsx
@@ -146,7 +146,7 @@ export const SwipeableView = forwardRef<SwipeableViewRef, SwipeableViewProps>((
             const yDiff = Math.abs(evt.changedTouches[0].y - initialTouchLocation.value.y);
             const isHorizontalPanning = xDiff > yDiff;
 
-            if (isHorizontalPanning) {
+            if (isHorizontalPanning && isSwipeable) {
                 state.activate();
             } else {
                 state.fail();


### PR DESCRIPTION
Fixes an issue where dragging would stop working for us when panning too far horizontally.

P.S. Have patched this locally already - don't worry about rushing a release on our account.